### PR TITLE
Add a layer for HTTP Responses

### DIFF
--- a/lib/conta_azul_api.rb
+++ b/lib/conta_azul_api.rb
@@ -1,6 +1,7 @@
 require 'conta_azul_api/configuration'
 require 'conta_azul_api/authentication'
 require 'conta_azul_api/request'
+require 'conta_azul_api/http_response'
 require 'conta_azul_api/version'
 require 'conta_azul_api/product'
 require 'conta_azul_api/customer'

--- a/lib/conta_azul_api/authentication.rb
+++ b/lib/conta_azul_api/authentication.rb
@@ -37,7 +37,7 @@ module ContaAzulApi
       new_access_tokens = ContaAzulApi::Request.new.post(
         endpoint: "oauth2/token?#{query_vars}",
         authorization: "Basic #{client_credential}"
-      )
+      ).body
 
       @last_authentication = ::CaAuthHistory.create!(
         access_token:  new_access_tokens['access_token'],

--- a/lib/conta_azul_api/customer.rb
+++ b/lib/conta_azul_api/customer.rb
@@ -11,42 +11,42 @@ module ContaAzulApi
     CUSTOMER_ENDPOINT = 'v1/customers'
 
     def self.create(attributes = {})
-      customer = ContaAzulApi::Request.post(
+      customer_response = ContaAzulApi::Request.post(
         endpoint: "#{CUSTOMER_ENDPOINT}", body: attributes, authorization: request_authorization
       )
 
-      raise NotCreated if customer.nil?
+      raise NotCreated unless customer_response.success?
 
-      OpenStruct.new(customer)
+      OpenStruct.new(customer_response.body)
     end
 
     def self.find(customer_id)
-      customer = ContaAzulApi::Request.get(
+      customer_response = ContaAzulApi::Request.get(
         authorization: request_authorization,
         endpoint:      "#{CUSTOMER_ENDPOINT}/#{customer_id}"
       )
 
-      raise NotFound if customer.nil?
+      raise NotFound if customer_response.status_code == :not_found
 
-      OpenStruct.new(customer)
+      OpenStruct.new(customer_response.body)
     end
 
     def self.search(value, size: 10)
-      customers = ContaAzulApi::Request.get(
+      customer_response = ContaAzulApi::Request.get(
         authorization: request_authorization,
         endpoint:      "#{CUSTOMER_ENDPOINT}?search=#{value}&size=#{size}"
       )
 
-      customers.map { |customer| OpenStruct.new(customer) }
+      customer_response.body.map { |customer| OpenStruct.new(customer) }
     end
 
     def self.find_by_name(name)
-      customers = ContaAzulApi::Request.get(
+      customer_response = ContaAzulApi::Request.get(
         authorization: request_authorization,
         endpoint:      "#{CUSTOMER_ENDPOINT}?name=#{name}"
       )
 
-      customers.map { |customer| OpenStruct.new(customer) }
+      customer_response.body.map { |customer| OpenStruct.new(customer) }
     end
   end
 end

--- a/lib/conta_azul_api/http_response.rb
+++ b/lib/conta_azul_api/http_response.rb
@@ -3,18 +3,6 @@ require 'active_support/gzip'
 
 module ContaAzulApi
   class HttpResponse
-    HTTP_STATUS_CODE = {
-      '200': :ok,
-      '201': :created,
-      '400': :bad_request,
-      '401': :unauthorized,
-      '403': :forbidden,
-      '404': :not_found,
-      '422': :unprocessable_entity,
-      '500': :internal_server_error,
-      '503': :service_unavailabe
-    }
-
     def initialize(http_response)
       @raw_response = http_response
     end
@@ -32,6 +20,18 @@ module ContaAzulApi
     end
 
     private
+
+    HTTP_STATUS_CODE = {
+      '200': :ok,
+      '201': :created,
+      '400': :bad_request,
+      '401': :unauthorized,
+      '403': :forbidden,
+      '404': :not_found,
+      '422': :unprocessable_entity,
+      '500': :internal_server_error,
+      '503': :service_unavailabe
+    }
 
     attr_reader :raw_response
 

--- a/lib/conta_azul_api/http_response.rb
+++ b/lib/conta_azul_api/http_response.rb
@@ -5,14 +5,15 @@ module ContaAzulApi
   class HttpResponse
     def initialize(http_response)
       @raw_response = http_response
+      @response_code = @raw_response.code.to_i
     end
 
     def status_code
-      HTTP_STATUS_CODE[raw_response.code.to_sym]
+      HTTP_STATUS_CODE[response_code]
     end
 
     def success?
-      raw_response.code.start_with?('20')
+      response_code.between?(200, 299)
     end
 
     def body
@@ -22,18 +23,18 @@ module ContaAzulApi
     private
 
     HTTP_STATUS_CODE = {
-      '200': :ok,
-      '201': :created,
-      '400': :bad_request,
-      '401': :unauthorized,
-      '403': :forbidden,
-      '404': :not_found,
-      '422': :unprocessable_entity,
-      '500': :internal_server_error,
-      '503': :service_unavailabe
+      200 => :ok,
+      201 => :created,
+      400 => :bad_request,
+      401 => :unauthorized,
+      403 => :forbidden,
+      404 => :not_found,
+      422 => :unprocessable_entity,
+      500 => :internal_server_error,
+      503 => :service_unavailabe
     }
 
-    attr_reader :raw_response
+    attr_reader :raw_response, :response_code
 
     def format_response_body
       decompressed_data = ActiveSupport::Gzip.decompress(raw_response.body)

--- a/lib/conta_azul_api/http_response.rb
+++ b/lib/conta_azul_api/http_response.rb
@@ -1,0 +1,46 @@
+require 'json'
+require 'active_support/gzip'
+
+module ContaAzulApi
+  class HttpResponse
+    HTTP_STATUS_CODE = {
+      '200': :ok,
+      '201': :created,
+      '400': :bad_request,
+      '401': :unauthorized,
+      '403': :forbidden,
+      '404': :not_found,
+      '422': :unprocessable_entity,
+      '500': :internal_server_error,
+      '503': :service_unavailabe
+    }
+
+    def initialize(http_response)
+      @raw_response = http_response
+    end
+
+    def status_code
+      HTTP_STATUS_CODE[raw_response.code.to_sym]
+    end
+
+    def success?
+      raw_response.code.start_with?('20')
+    end
+
+    def body
+      format_response_body
+    end
+
+    private
+
+    attr_reader :raw_response
+
+    def format_response_body
+      decompressed_data = ActiveSupport::Gzip.decompress(raw_response.body)
+
+      JSON.parse(decompressed_data)
+    rescue Zlib::GzipFile::Error # not a gzip
+      JSON.parse(raw_response.body)
+    end
+  end
+end

--- a/lib/conta_azul_api/product.rb
+++ b/lib/conta_azul_api/product.rb
@@ -10,20 +10,20 @@ module ContaAzulApi
     MAX_PRODUCTS_PER_PAGE = 200
 
     def self.find(product_id)
-      product = ContaAzulApi::Request.new.get(
+      product_response = ContaAzulApi::Request.new.get(
         endpoint: "#{PRODUCT_ENDPOINT}/#{product_id}", authorization: request_authorization
       )
-      raise NotFound if product.nil?
+      raise NotFound if product_response.status_code == :not_found
 
-      OpenStruct.new(product)
+      OpenStruct.new(product_response.body)
     end
 
     def self.all
-      products = ContaAzulApi::Request.new.get(
+      products_response = ContaAzulApi::Request.new.get(
         endpoint: "#{PRODUCT_ENDPOINT}?size=#{MAX_PRODUCTS_PER_PAGE}", authorization: request_authorization
       )
 
-      products.map { |product| OpenStruct.new(product) }
+      products_response.body.map { |product| OpenStruct.new(product) }
     end
 
     def self.filter_by(name:)

--- a/lib/conta_azul_api/request.rb
+++ b/lib/conta_azul_api/request.rb
@@ -46,14 +46,10 @@ module ContaAzulApi
       request.body = body
 
       logger.info("Requesting #{method.to_s} #{url} with body: #{body}")
-
       response = http.request(request)
 
       logger.info("Response body: ```\n#{response.read_body.to_s}\n```, Status: #{response.code}")
-
-      if response.code.start_with?('20')
-        format_response_body(response.read_body)
-      end
+      ContaAzulApi::HttpResponse.new(response)
     end
 
     def format_response_body(response_body)

--- a/spec/conta_azul_api/http_response_spec.rb
+++ b/spec/conta_azul_api/http_response_spec.rb
@@ -2,33 +2,34 @@ RSpec.describe ContaAzulApi::HttpResponse do
   let(:product_payload) { File.read('spec/fixtures/products_endpoints/find_by_id.json') }
 
   before do
-    stub_request(:get, 'https://api.contaazul.com/v1/products/c7288c09-829d-48b9-aee2-4f744e380587').
-      to_return(status: response_status, body: product_payload, headers: {})
-
     logger = double(:logger, info: '')
     allow(Rails).to receive(:logger).and_return(logger)
   end
 
-  subject(:response) do
-    ContaAzulApi::Request.new.get(
-      endpoint: 'v1/products/c7288c09-829d-48b9-aee2-4f744e380587',
-      authorization: 'fake_auth'
-    )
-  end
-
   describe '#status_code' do
     context 'when it is a successfull request' do
-      let(:response_status) { 200 }
-
       it 'returns the response status code' do
+        stub_request(:get, 'https://api.contaazul.com/v1/products/c7288c09-829d-48b9-aee2-4f744e380587').
+          to_return(status: 200, body: product_payload, headers: {})
+
+        response = ContaAzulApi::Request.new.get(
+          endpoint: 'v1/products/c7288c09-829d-48b9-aee2-4f744e380587',
+          authorization: 'fake_auth'
+        )
         expect(response.status_code).to eq(:ok)
       end
     end
 
     context 'when it is a unsuccessfull request' do
-      let(:response_status) { 404 }
-
       it 'returns the response status code' do
+        stub_request(:get, 'https://api.contaazul.com/v1/products/c7288c09-829d-48b9-aee2-4f744e380587').
+          to_return(status: 404, body: product_payload, headers: {})
+
+        response = ContaAzulApi::Request.new.get(
+          endpoint: 'v1/products/c7288c09-829d-48b9-aee2-4f744e380587',
+          authorization: 'fake_auth'
+        )
+
         expect(response.status_code).to eq(:not_found)
       end
     end
@@ -36,26 +37,44 @@ RSpec.describe ContaAzulApi::HttpResponse do
 
   describe '#success?' do
     context 'when it is a successfull request' do
-      let(:response_status) { 200 }
-
       it 'returns true when success' do
+        stub_request(:get, 'https://api.contaazul.com/v1/products/c7288c09-829d-48b9-aee2-4f744e380587').
+          to_return(status: 200, body: product_payload, headers: {})
+
+        response = ContaAzulApi::Request.new.get(
+          endpoint: 'v1/products/c7288c09-829d-48b9-aee2-4f744e380587',
+          authorization: 'fake_auth'
+        )
+
         expect(response.success?).to be true
       end
     end
 
     context 'when it is a unsuccessfull request' do
-      let(:response_status) { 404 }
-
       it 'returns true when success' do
+        stub_request(:get, 'https://api.contaazul.com/v1/products/c7288c09-829d-48b9-aee2-4f744e380587').
+          to_return(status: 404, body: product_payload, headers: {})
+
+        response = ContaAzulApi::Request.new.get(
+          endpoint: 'v1/products/c7288c09-829d-48b9-aee2-4f744e380587',
+          authorization: 'fake_auth'
+        )
+
         expect(response.success?).to be false
       end
     end
   end
 
   describe '#body' do
-    let(:response_status) { 200 }
-
     it 'returns a hash format body' do
+      stub_request(:get, 'https://api.contaazul.com/v1/products/c7288c09-829d-48b9-aee2-4f744e380587').
+        to_return(status: 200, body: product_payload, headers: {})
+
+      response = ContaAzulApi::Request.new.get(
+        endpoint: 'v1/products/c7288c09-829d-48b9-aee2-4f744e380587',
+        authorization: 'fake_auth'
+      )
+
       expect(response.body).to be_a Hash
       expect(response.body).to eq(JSON.parse(product_payload))
     end

--- a/spec/conta_azul_api/http_response_spec.rb
+++ b/spec/conta_azul_api/http_response_spec.rb
@@ -1,0 +1,63 @@
+RSpec.describe ContaAzulApi::HttpResponse do
+  let(:product_payload) { File.read('spec/fixtures/products_endpoints/find_by_id.json') }
+
+  before do
+    stub_request(:get, 'https://api.contaazul.com/v1/products/c7288c09-829d-48b9-aee2-4f744e380587').
+      to_return(status: response_status, body: product_payload, headers: {})
+
+    logger = double(:logger, info: '')
+    allow(Rails).to receive(:logger).and_return(logger)
+  end
+
+  subject(:response) do
+    ContaAzulApi::Request.new.get(
+      endpoint: 'v1/products/c7288c09-829d-48b9-aee2-4f744e380587',
+      authorization: 'fake_auth'
+    )
+  end
+
+  describe '#status_code' do
+    context 'when it is a successfull request' do
+      let(:response_status) { 200 }
+
+      it 'returns the response status code' do
+        expect(response.status_code).to eq(:ok)
+      end
+    end
+
+    context 'when it is a unsuccessfull request' do
+      let(:response_status) { 404 }
+
+      it 'returns the response status code' do
+        expect(response.status_code).to eq(:not_found)
+      end
+    end
+  end
+
+  describe '#success?' do
+    context 'when it is a successfull request' do
+      let(:response_status) { 200 }
+
+      it 'returns true when success' do
+        expect(response.success?).to be true
+      end
+    end
+
+    context 'when it is a unsuccessfull request' do
+      let(:response_status) { 404 }
+
+      it 'returns true when success' do
+        expect(response.success?).to be false
+      end
+    end
+  end
+
+  describe '#body' do
+    let(:response_status) { 200 }
+
+    it 'returns a hash format body' do
+      expect(response.body).to be_a Hash
+      expect(response.body).to eq(JSON.parse(product_payload))
+    end
+  end
+end


### PR DESCRIPTION
This PR is a sugestion to make it easier to handle HTTP responses from API, nowadays you have just a few statuses (200, 401 and 404) mapped, but when I was developing #11 I came across a few other like 400, 422, 201. 

The idea is pretty simple, it's just to encapsulate the response in a new class that gives us some helper methods like `success?`, `stauts_code` and `body`. In the feature, you may handle content-types translation there too.
