### PR TITLE
Inject logger class

### DIFF
--- a/lib/conta_azul_api/authentication.rb
+++ b/lib/conta_azul_api/authentication.rb
@@ -34,7 +34,7 @@ module ContaAzulApi
         raise InvalidGrantType
       end
 
-      new_access_tokens = ContaAzulApi::Request.post(
+      new_access_tokens = ContaAzulApi::Request.new.post(
         endpoint: "oauth2/token?#{query_vars}",
         authorization: "Basic #{client_credential}"
       )

--- a/lib/conta_azul_api/product.rb
+++ b/lib/conta_azul_api/product.rb
@@ -10,7 +10,7 @@ module ContaAzulApi
     MAX_PRODUCTS_PER_PAGE = 200
 
     def self.find(product_id)
-      product = ContaAzulApi::Request.get(
+      product = ContaAzulApi::Request.new.get(
         endpoint: "#{PRODUCT_ENDPOINT}/#{product_id}", authorization: request_authorization
       )
       raise NotFound if product.nil?
@@ -19,7 +19,7 @@ module ContaAzulApi
     end
 
     def self.all
-      products = ContaAzulApi::Request.get(
+      products = ContaAzulApi::Request.new.get(
         endpoint: "#{PRODUCT_ENDPOINT}?size=#{MAX_PRODUCTS_PER_PAGE}", authorization: request_authorization
       )
 

--- a/lib/conta_azul_api/request.rb
+++ b/lib/conta_azul_api/request.rb
@@ -8,24 +8,30 @@ require 'active_support/gzip'
 require 'rails'
 
 module ContaAzulApi
-  module Request
+  class Request
     CONTA_AZUL_DOMAIN = 'https://api.contaazul.com/%s'
     HTTP_METHODS_CLASS = {
       post: Net::HTTP::Post,
       get:  Net::HTTP::Get
     }
 
-    def self.get(endpoint:, authorization:)
+    def initialize(logger: Rails.logger)
+      @logger = logger
+    end
+
+    def get(endpoint:, authorization:)
       request(method: :get, endpoint: endpoint, authorization: authorization)
     end
 
-    def self.post(endpoint:, body: nil, authorization:)
+    def post(endpoint:, body: nil, authorization:)
       request(method: :post, endpoint: endpoint, body: body, authorization: authorization)
     end
 
     private
 
-    def self.request(method:, endpoint:, body: nil, authorization:)
+    attr_reader :logger
+
+    def request(method:, endpoint:, body: nil, authorization:)
       url = URI(CONTA_AZUL_DOMAIN % endpoint)
 
       http = Net::HTTP.new(url.host, url.port)
@@ -39,18 +45,18 @@ module ContaAzulApi
       request['Accept'] = 'application/json'
       request.body = body
 
-      Rails.logger.info("Requesting #{method.to_s} #{url} with body: #{body}")
+      logger.info("Requesting #{method.to_s} #{url} with body: #{body}")
 
       response = http.request(request)
 
-      Rails.logger.info("Response body: ```\n#{response.read_body.to_s}\n```, Status: #{response.code}")
+      logger.info("Response body: ```\n#{response.read_body.to_s}\n```, Status: #{response.code}")
 
       if response.code.start_with?('20')
         format_response_body(response.read_body)
       end
     end
 
-    def self.format_response_body(response_body)
+    def format_response_body(response_body)
       decompressed_data = ActiveSupport::Gzip.decompress(response_body)
 
       JSON.parse(decompressed_data)

--- a/spec/conta_azul_api/authentication_spec.rb
+++ b/spec/conta_azul_api/authentication_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe ContaAzulApi::Authentication do
   describe '.authentication_expired?' do
     before do
       stub_const('CaAuthHistory', FakeCaAuthHistory)
+
+      logger = double(:logger, info: '')
+      allow(Rails).to receive(:logger).and_return(logger)
     end
 
     it 'returns positive when no access token is provided' do

--- a/spec/conta_azul_api/product_spec.rb
+++ b/spec/conta_azul_api/product_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe ContaAzulApi::Product do
       to_return(status: 200, body: File.read('spec/fixtures/refresh_oauth_token.json'))
 
     stub_const('CaAuthHistory', FakeCaAuthHistory)
+
+    logger = double(:logger, info: '')
+    allow(Rails).to receive(:logger).and_return(logger)
   end
 
   describe '.find' do


### PR DESCRIPTION
This is a suggestion to resolve how you handle the logger class. Basically, I changed the `ContaAzulApi::Request` to be a class and not a module, so we can inject the logger class we want at the initializer and I've mocked them with stubs in the tests and now the suite passes.